### PR TITLE
Fixed incorrect use of TextureRegion UV

### DIFF
--- a/colorful/src/main/java/com/github/tommyettinger/colorful/cielab/ColorfulBatch.java
+++ b/colorful/src/main/java/com/github/tommyettinger/colorful/cielab/ColorfulBatch.java
@@ -1213,7 +1213,7 @@ public class ColorfulBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/colorful/src/main/java/com/github/tommyettinger/colorful/hsluv/ColorfulBatch.java
+++ b/colorful/src/main/java/com/github/tommyettinger/colorful/hsluv/ColorfulBatch.java
@@ -1730,7 +1730,7 @@ public class ColorfulBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/colorful/src/main/java/com/github/tommyettinger/colorful/ipt/ColorfulBatch.java
+++ b/colorful/src/main/java/com/github/tommyettinger/colorful/ipt/ColorfulBatch.java
@@ -1186,7 +1186,7 @@ public class ColorfulBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/colorful/src/main/java/com/github/tommyettinger/colorful/ipt_hq/ColorfulBatch.java
+++ b/colorful/src/main/java/com/github/tommyettinger/colorful/ipt_hq/ColorfulBatch.java
@@ -1196,7 +1196,7 @@ public class ColorfulBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/colorful/src/main/java/com/github/tommyettinger/colorful/oklab/ColorfulBatch.java
+++ b/colorful/src/main/java/com/github/tommyettinger/colorful/oklab/ColorfulBatch.java
@@ -1325,7 +1325,7 @@ public class ColorfulBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/colorful/src/main/java/com/github/tommyettinger/colorful/rgb/ColorfulBatch.java
+++ b/colorful/src/main/java/com/github/tommyettinger/colorful/rgb/ColorfulBatch.java
@@ -1298,7 +1298,7 @@ public class ColorfulBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/colorful/src/main/java/com/github/tommyettinger/colorful/ycwcm/ColorfulBatch.java
+++ b/colorful/src/main/java/com/github/tommyettinger/colorful/ycwcm/ColorfulBatch.java
@@ -1150,7 +1150,7 @@ public class ColorfulBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/colorful/src/test/java/com/github/tommyettinger/colorful/rgb/RGBHSLBatch.java
+++ b/colorful/src/test/java/com/github/tommyettinger/colorful/rgb/RGBHSLBatch.java
@@ -1159,7 +1159,7 @@ public class RGBHSLBatch implements Batch {
 
         float u = region.getU();
         float v = region.getV2();
-        float u2 = region.getV2();
+        float u2 = region.getU2();
         float v2 = region.getV();
 
         final float color = this.color;

--- a/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/cielab/ColorfulBatch.html
+++ b/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/cielab/ColorfulBatch.html
@@ -1226,7 +1226,7 @@
 <span class="source-line-no">1213</span><span id="line-1213"></span>
 <span class="source-line-no">1214</span><span id="line-1214">        float u = region.getU();</span>
 <span class="source-line-no">1215</span><span id="line-1215">        float v = region.getV2();</span>
-<span class="source-line-no">1216</span><span id="line-1216">        float u2 = region.getV2();</span>
+<span class="source-line-no">1216</span><span id="line-1216">        float u2 = region.getU2();</span>
 <span class="source-line-no">1217</span><span id="line-1217">        float v2 = region.getV();</span>
 <span class="source-line-no">1218</span><span id="line-1218"></span>
 <span class="source-line-no">1219</span><span id="line-1219">        final float color = this.color;</span>

--- a/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/hsluv/ColorfulBatch.html
+++ b/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/hsluv/ColorfulBatch.html
@@ -1743,7 +1743,7 @@
 <span class="source-line-no">1730</span><span id="line-1730"></span>
 <span class="source-line-no">1731</span><span id="line-1731">        float u = region.getU();</span>
 <span class="source-line-no">1732</span><span id="line-1732">        float v = region.getV2();</span>
-<span class="source-line-no">1733</span><span id="line-1733">        float u2 = region.getV2();</span>
+<span class="source-line-no">1733</span><span id="line-1733">        float u2 = region.getU2();</span>
 <span class="source-line-no">1734</span><span id="line-1734">        float v2 = region.getV();</span>
 <span class="source-line-no">1735</span><span id="line-1735"></span>
 <span class="source-line-no">1736</span><span id="line-1736">        final float color = this.color;</span>

--- a/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/ipt/ColorfulBatch.html
+++ b/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/ipt/ColorfulBatch.html
@@ -1199,7 +1199,7 @@
 <span class="source-line-no">1186</span><span id="line-1186"></span>
 <span class="source-line-no">1187</span><span id="line-1187">        float u = region.getU();</span>
 <span class="source-line-no">1188</span><span id="line-1188">        float v = region.getV2();</span>
-<span class="source-line-no">1189</span><span id="line-1189">        float u2 = region.getV2();</span>
+<span class="source-line-no">1189</span><span id="line-1189">        float u2 = region.getU2();</span>
 <span class="source-line-no">1190</span><span id="line-1190">        float v2 = region.getV();</span>
 <span class="source-line-no">1191</span><span id="line-1191"></span>
 <span class="source-line-no">1192</span><span id="line-1192">        final float color = this.color;</span>

--- a/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/ipt_hq/ColorfulBatch.html
+++ b/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/ipt_hq/ColorfulBatch.html
@@ -1209,7 +1209,7 @@
 <span class="source-line-no">1196</span><span id="line-1196"></span>
 <span class="source-line-no">1197</span><span id="line-1197">        float u = region.getU();</span>
 <span class="source-line-no">1198</span><span id="line-1198">        float v = region.getV2();</span>
-<span class="source-line-no">1199</span><span id="line-1199">        float u2 = region.getV2();</span>
+<span class="source-line-no">1199</span><span id="line-1199">        float u2 = region.getU2();</span>
 <span class="source-line-no">1200</span><span id="line-1200">        float v2 = region.getV();</span>
 <span class="source-line-no">1201</span><span id="line-1201"></span>
 <span class="source-line-no">1202</span><span id="line-1202">        final float color = this.color;</span>

--- a/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/oklab/ColorfulBatch.html
+++ b/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/oklab/ColorfulBatch.html
@@ -1338,7 +1338,7 @@
 <span class="source-line-no">1325</span><span id="line-1325"></span>
 <span class="source-line-no">1326</span><span id="line-1326">        float u = region.getU();</span>
 <span class="source-line-no">1327</span><span id="line-1327">        float v = region.getV2();</span>
-<span class="source-line-no">1328</span><span id="line-1328">        float u2 = region.getV2();</span>
+<span class="source-line-no">1328</span><span id="line-1328">        float u2 = region.getU2();</span>
 <span class="source-line-no">1329</span><span id="line-1329">        float v2 = region.getV();</span>
 <span class="source-line-no">1330</span><span id="line-1330"></span>
 <span class="source-line-no">1331</span><span id="line-1331">        final float color = this.color;</span>

--- a/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/rgb/ColorfulBatch.html
+++ b/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/rgb/ColorfulBatch.html
@@ -1311,7 +1311,7 @@
 <span class="source-line-no">1298</span><span id="line-1298"></span>
 <span class="source-line-no">1299</span><span id="line-1299">        float u = region.getU();</span>
 <span class="source-line-no">1300</span><span id="line-1300">        float v = region.getV2();</span>
-<span class="source-line-no">1301</span><span id="line-1301">        float u2 = region.getV2();</span>
+<span class="source-line-no">1301</span><span id="line-1301">        float u2 = region.getU2();</span>
 <span class="source-line-no">1302</span><span id="line-1302">        float v2 = region.getV();</span>
 <span class="source-line-no">1303</span><span id="line-1303"></span>
 <span class="source-line-no">1304</span><span id="line-1304">        final float color = this.color;</span>

--- a/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/ycwcm/ColorfulBatch.html
+++ b/docs/colorful/apidocs/src-html/com/github/tommyettinger/colorful/ycwcm/ColorfulBatch.html
@@ -1163,7 +1163,7 @@
 <span class="source-line-no">1150</span><span id="line-1150"></span>
 <span class="source-line-no">1151</span><span id="line-1151">        float u = region.getU();</span>
 <span class="source-line-no">1152</span><span id="line-1152">        float v = region.getV2();</span>
-<span class="source-line-no">1153</span><span id="line-1153">        float u2 = region.getV2();</span>
+<span class="source-line-no">1153</span><span id="line-1153">        float u2 = region.getU2();</span>
 <span class="source-line-no">1154</span><span id="line-1154">        float v2 = region.getV();</span>
 <span class="source-line-no">1155</span><span id="line-1155"></span>
 <span class="source-line-no">1156</span><span id="line-1156">        final float color = this.color;</span>


### PR DESCRIPTION
Hey Tet!

I was looking to skew a TextureRegion and the texture UV was showing incorrectly. 
Upon digging into the source, the U2 coordinate was grabbing the V2 coordinate instead. This doesn't match the base spriteBatch implementation, or work, so I updated it to use the correct U2. 

I changed all occurrences of this and may have affected some generated files that don't need the change. So please double check that before merging!

Thanks,
tecksup